### PR TITLE
Fix DB initialization path

### DIFF
--- a/network-dashboard/.gitignore
+++ b/network-dashboard/.gitignore
@@ -201,3 +201,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Local database files
+backend/data/

--- a/network-dashboard/backend/app/database.py
+++ b/network-dashboard/backend/app/database.py
@@ -1,10 +1,16 @@
 """Database connection and models for the network dashboard."""
 
 from datetime import datetime
+import os
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import declarative_base, relationship, sessionmaker, Session
 
-DATABASE_URL = "sqlite:///network_dashboard.db"
+# Create a persistent data directory inside ``backend`` to store the DB file
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(os.path.dirname(BASE_DIR), "data")
+os.makedirs(DATA_DIR, exist_ok=True)
+
+DATABASE_URL = f"sqlite:///{os.path.join(DATA_DIR, 'network_dashboard.db')}"
 
 Base = declarative_base()
 engine = create_engine(DATABASE_URL, echo=False)

--- a/network-dashboard/backend/app/main.py
+++ b/network-dashboard/backend/app/main.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI
 from apscheduler.schedulers.background import BackgroundScheduler
 from app.api import router as api_router
 from app.scanner import escaneo_completo
+from app.database import crear_base_datos
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -36,6 +37,7 @@ def setup_api() -> FastAPI:
 
 
 app = setup_api()
+crear_base_datos()
 
 # Scheduler setup
 scheduler = BackgroundScheduler()


### PR DESCRIPTION
## Summary
- store the SQLite database inside `backend/data`
- create the DB schema on startup
- ignore the generated data directory

## Testing
- `PYTHONPATH=network-dashboard/backend python - <<'PY'
from app.database import crear_base_datos, DATA_DIR
import os
print('DATA_DIR', DATA_DIR)
crear_base_datos()
print('db exists', os.path.exists(os.path.join(DATA_DIR, 'network_dashboard.db')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687ca70bbb28832e9100b3a435023035