### PR TITLE
Fix NOT NULL error on port updates

### DIFF
--- a/network-dashboard/backend/app/database.py
+++ b/network-dashboard/backend/app/database.py
@@ -41,7 +41,13 @@ class Dispositivo(Base):
     vendor = Column(String, nullable=True)
     detectado = Column(DateTime, default=datetime.utcnow)
 
-    puertos = relationship("Puerto", backref="dispositivo", cascade="all, delete")
+    # Delete orphaned port rows when they are removed from the relationship to
+    # avoid NULL ``dispositivo_id`` errors when updating devices.
+    puertos = relationship(
+        "Puerto",
+        backref="dispositivo",
+        cascade="all, delete, delete-orphan",
+    )
 
 
 def crear_base_datos() -> None:


### PR DESCRIPTION
## Summary
- remove NOT NULL violations by deleting orphan ports when a device is updated

## Testing
- `python -m py_compile network-dashboard/backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687cacf3db88832ea2f167bf65e37826