### PR TITLE
Fix session usage in scanner metrics

### DIFF
--- a/network-dashboard/backend/app/database.py
+++ b/network-dashboard/backend/app/database.py
@@ -66,7 +66,7 @@ def crear_base_datos() -> None:
     Base.metadata.create_all(bind=engine)
 
 
-def insertar_dispositivo(session: Session, data: dict) -> None:
+def insertar_dispositivo(session: Session, data: dict) -> Dispositivo:
     """Inserta un nuevo dispositivo y sus puertos en la base de datos.
 
     Args:
@@ -92,9 +92,11 @@ def insertar_dispositivo(session: Session, data: dict) -> None:
 
     session.add(dispositivo)
     session.commit()
+    session.refresh(dispositivo)
+    return dispositivo
 
 
-def actualizar_dispositivo(session: Session, data: dict) -> None:
+def actualizar_dispositivo(session: Session, data: dict) -> Dispositivo:
     """Actualiza un dispositivo existente, sobrescribiendo sus datos y puertos.
 
     Args:
@@ -103,8 +105,8 @@ def actualizar_dispositivo(session: Session, data: dict) -> None:
     """
     dispositivo = session.query(Dispositivo).filter_by(ip=data["ip"]).first()
     if not dispositivo:
-        insertar_dispositivo(session, data)
-        return
+        dispositivo = insertar_dispositivo(session, data)
+        return dispositivo
 
     dispositivo.estado = data["estado"]
     dispositivo.hostname = data.get("hostname")
@@ -122,6 +124,8 @@ def actualizar_dispositivo(session: Session, data: dict) -> None:
         ))
 
     session.commit()
+    session.refresh(dispositivo)
+    return dispositivo
 
 
 def insertar_o_actualizar_dispositivo(data: dict) -> None:
@@ -151,4 +155,5 @@ __all__ = [
     "insertar_dispositivo",
     "actualizar_dispositivo",
     "insertar_o_actualizar_dispositivo",
+    "guardar_metrica",
 ]

--- a/network-dashboard/backend/app/scanner.py
+++ b/network-dashboard/backend/app/scanner.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 import subprocess
 import nmap
 from app.database import SessionLocal
-from app.database import insertar_o_actualizar_dispositivo
+from app.database import actualizar_dispositivo
 from app.database import guardar_metrica
 
 
@@ -102,7 +102,7 @@ def escaneo_completo() -> None:
     resultados_finales = list(vistos.values())
 
     for dispositivo in resultados_finales:
-        insertar_o_actualizar_dispositivo(dispositivo)
+        db_obj = actualizar_dispositivo(session, dispositivo)
         latencia = obtener_latencia(dispositivo["ip"])
         guardar_metrica(session, dispositivo_id=db_obj.id, **latencia)
     print(f"Escaneo completo. {len(resultados_finales)} dispositivos activos detectados.")


### PR DESCRIPTION
## Summary
- return database objects when inserting/updating devices
- update scanner to use returned DB objects for metrics

## Testing
- `python3 -m py_compile network-dashboard/backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687cb66afbe4832eb0c469d2f61d6ae9